### PR TITLE
Single end support + fix module import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### Check pipeline
 2. Perform a dry run using: `snakemake -n`
 
-This step is strongly recommended. It will make sure the prepared workflow does not contain any error and will display the rules (steps) that need to be run in order to reach the specified target(s) (default targets include the dataframe of functional impact scores, which is produced during the very last step of the workflow). If you're running the workflow for the first time and you toggled in normalization with growth data, you should see a warning prompting you to edit the generated template file (for more details, go back to step 1).
+This step is strongly recommended. It will make sure the prepared workflow does not contain any error and will display the rules (steps) that need to be run in order to run the workflow (built dynamically based on the config). If you're running the workflow for the first time and you toggled in normalization with growth data, you should see a warning prompting you to edit the generated template file (for more details, go back to step 1).
 
 ### Run pipeline
 3. Run the workflow either locally: `snakemake` or send to SLURM: `snakemake --profile profiles/slurm`.

--- a/config/README.md
+++ b/config/README.md
@@ -8,21 +8,21 @@ Unless specified otherwise, most file paths and parameters can be modified in th
 
 ### Sequencing data
 
-Please provide the raw reads (forward and reverse) of your DMS sequencing data in the `config/reads` folder (or specify a different path in the main config file). The file names should be featured in the layout (see section below).
+Please provide the raw reads (forward and, optionally, reverse) of your DMS sequencing data in the `config/reads` folder (or specify a different path in the main config file). The file names should be featured in the layout (see section below). Don't forget to specify in the config if you have provided paired-end reads or not.
 
 ### Layout
 
 Please provide a csv-formatted layout of your samples. The file should be named `layout.csv` and be located in the `config/project_files` folder. Here is [an example](project_files/layout.csv). The file should contain the following columns:
-- Sample_name: the unique identifier for each of your samples. The sample name does not need to contain information about the timepoint or replicate, since these correspond to other columns
+- Sample_name: the unique identifier for each of your samples.
 - R1: base name of the fastq file for forward (R1) reads (can be gzipped), including extension
-- R2: base name of the fastq file for reverse (R2) reads (can be gzipped), including extension
-- N_forward: the 5'-3' DNA sequence corresponding to the fixed region upstream of the mutated sequence or anything that can be used as -g flag with cutadapt (including complex patterns such as 'NNATG;optional...ATG', in which case do not forget the single quotes)
-- N_reverse: the 5'-3' DNA sequence corresponding to the fixed region 5' of the mutated sequence on the reverse strand or anything that can be used as -G flag with cutadapt (same requirements as above)
+- R2: base name of the fastq file for reverse (R2) reads (can be gzipped), including extension. Leave empty if you provide single-end sequencing data.
+- N_forward: the 5'-3' DNA sequence corresponding to the fixed region upstream of the mutated sequence or anything that can be used as -g flag with cutadapt (including complex patterns such as 'NNATG;optional...ATG', in which case do not forget the single quotes). For single-end sequencing data, please specify both constant sequences upstream and downstream (on the same strand) separated by '...', e.g. AAAAGCTG...GCGCTAAAT (no need for single quotes)
+- N_reverse: the 5'-3' DNA sequence corresponding to the fixed region 5' of the mutated sequence on the reverse strand or anything that can be used as -G flag with cutadapt (same requirements as above). Leave empty if you provide single-end sequencing data.
 - Mutated_seq: the unique identifier for the mutated DNA sequence, should be the same for all samples in which the same sequence was mutated
 - Pos_start: starting position in the protein sequence. If you've mutated several regions/fragments in a coding gene, this position should refer to the full-length protein sequence
 - Replicate: e.g. "R1"
 - Timepoint: "T0", "T1", etc. Intermediate timepoints are optional.
-- Report: "yes" (or a different truthy value) to include the sample in the HTML report.
+- Report: "yes" (or a different truthy value) to include the sample in the HTML report. Leave empty or enter non-truthy value to exclude from report. Samples sharing sets of conditions with sample marked for reporting will be automatically included, regardless of what you enter.
 
 Finally, additional columns can be added by the user to specify what makes this sample unique. These are referred to as "sample attributes" and could correspond to the genetic background, the fragment/region of the gene if it applies, the drug used for selection, etc. In summary, a "sample" is any unique combination of sample attributes + Replicate + Timepoint and should be associated to 2 fastq files, for the forward and reverse reads, respectively. Sample attributes = attributes related to Mutated_seq + optional attributes.
 
@@ -36,7 +36,7 @@ Alternatively, you can provide the same dataframe with an additional 'nt_seq' co
 
 ### Experimental design mode
 
-This is a fairly recent feature of gyōza and will be even more simplified in future versions, but is currently **essential**. Choose between 3 possible modes:
+This is a fairly recent feature of gyōza. Choose between 3 possible modes:
 - codon: Automatically generate all expected mutants based on the codon mode
 - provided: You provide the list of expected mutants or the dataframe of barcode-variant associations (see below)
 - random: Random mutagenesis - mutants observed in the sequencing data are directly annotated and filtered based on an acceptable number of amino acid changes
@@ -79,8 +79,9 @@ The main config file is located [here](config.yaml). Please make sure to:
 * list your sample attributes
 * replace all parameter values with the ones adapted for your project. Note: a first pass might be necessary to establish what would be a good **read count threshold**. Feel free to adjust it and re-run the workflow (if nothing else has changed, only the last steps should run again). This parameter is important because the "avg_scores" dataframe is built only upon "high confidence" variants, i.e. variants with a read count above the set threshold in all T0 replicates.
 * set the "perform qc" parameter to True if you want to analyze your raw FASTQ with FastQC (and generate a MultiQC report)
-* set the "normalize with gen" parameter to True if you want to normalize with the number of cellular generations
-* set the "generate report" parameter to True if you want the HTML report to be automatically generated upon full completion of the workflow
+* set the "process_read_counts" to True if you want to convert read counts to functional impact scores (False if you simply want read counts)
+* set the "normalize with gen" parameter to True if you want to normalize with the number of cellular generations (only valid if you opted in for processing read counts)
+* set the "generate report" parameter to True if you want the HTML report to be automatically generated upon completion of the workflow
 * edit all directory/file paths if necessary
 
 ## Note on validation

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,8 @@
 # Main configuration file for gyōza
 
 reads:
+    # Specify if reads are paired-end (True) or single-end (False)
+    paired: True
     # Specify path to directory containing sequencing data
     path: 'config/reads/'
 
@@ -56,6 +58,9 @@ filter:
 qc:
     # Set to True if you want to run FASTQC on all raw FASTQ files and generate a MultiQC report
     perform: True
+
+process_read_counts: True
+    # Set to True if you want to convert read counts into functional impact scores
 
 normalize:
     # Set to True if you want to normalize impact scores with the number of cellular generations

--- a/fulldoc/README.md
+++ b/fulldoc/README.md
@@ -66,7 +66,7 @@ cd gyoza
 > 
 > 4. Perform a dry run using: `snakemake -n`
 >
-> This step is strongly recommended. It will make sure the prepared workflow does not contain any error and will display the rules (steps) that need to be run in order to reach the specified target(s) (default targets include the dataframe of functional impact scores, which is produced during the very last step of the workflow). If you're running the workflow for the first time and you toggled in normalization with growth data, you should see a warning prompting you to edit the generated template file (for more details, go back to step 1).
+> This step is strongly recommended. It will make sure the prepared workflow does not contain any error and will display the rules (steps) that need to be run in order to run the workflow (built dynamically based on the config). If you're running the workflow for the first time and you toggled in normalization with growth data, you should see a warning prompting you to edit the generated template file (for more details, go back to step 1).
 
 ### Run pipeline
 
@@ -82,13 +82,13 @@ If snakemake is launched directly from the command line, the process will be out
 
 There are 3 possible options to get the prompt back and/or exit the terminal without aborting the workflow:
 1. Open a new tab on your terminal (may require to log into the session again)
-2. Use `nohup` (e.g. `nohup snakemake --use-conda`). Closing the tab will not abort the workflow.
+2. Use `nohup` (e.g. `nohup snakemake`). Closing the tab will not abort the workflow.
 3. Use the terminal multiplexer [`tmux`](https://github.com/tmux/tmux/wiki/Getting-Started). This way you can get the prompt back right away, exit without aborting and even reconnect to the session from a different machine.
 
 Please make sure `tmux` is installed (already installed on some servers). Then, follow the steps:
 1. Type `tmux new -s snakes` to launch a new tmux session
 2. Activate the conda env with `mamba activate gyoza` or `conda activate gyoza`
-3. Navigate to the Snakefile directory and launch the pipeline with `snakemake --profile profile`
+3. Navigate to the Snakefile directory and launch the pipeline with `snakemake --profile profiles/slurm`
 4. To close (detach) the session, type `<Ctrl+b>`, then `<d>`. You should see the message: `[detached (from session snakes)]`
 5. To reconnect (attach) to the session, for example from a different machine: `tmux attach -t snakes`. You can also see existing sessions with `tmux ls`.
 6. To close the session when everything is finished, type `<Ctrl+b>`, then `<:>`, then `kill-session` and finally `<Enter>`.
@@ -103,9 +103,9 @@ Please make sure `tmux` is installed (already installed on some servers). Then, 
 
 >[!TIP]
 >
-> Similarly, you can omit rules from the workflow. This can be really useful to obtain read counts from any library (typically T0 if you simply want to assess diversity before screening)
+> Similarly, you can omit rules from the workflow.
 >
-> For example: `snakemake --omit process_read_counts`
+> For example: `snakemake --omit rule_to_omit`
 
 >[!NOTE]
 >

--- a/profiles/slurm/config.v8+.yaml
+++ b/profiles/slurm/config.v8+.yaml
@@ -26,7 +26,7 @@ default-resources:
 # Resources allocated should prevent overallocation but might not be enough at first attempt
 set-resources:
   fastqc:
-    time: max(int(0.002 * input.size_mb * attempt + 0.99), 1)
+    time: max(int(0.005 * input.size_mb * attempt + 0.99), 1)
   compare_to_sequencing:
     mem_gb: max(int(0.15 * input.size_mb * attempt + 0.99), 2)
     time: max(int(0.15 * input.size_mb * attempt + 0.99), 2)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -58,25 +58,6 @@ rule all:
         get_target(),
 
 
-##### Copy scripts package into Snakemake folder #####
-# This is a workaround to be able to import modules from the scripts folder
-# Even when running a snakedeployed workflow
-onstart:
-    import os, shutil, sys
-
-    src = os.path.abspath("scripts")
-    dst_base = os.path.join(".snakemake", "scripts")
-    dst = os.path.join(dst_base, "scripts")
-
-    if os.path.isdir(src):
-        shutil.rmtree(dst, ignore_errors=True)
-        shutil.copytree(src, dst)
-        open(os.path.join(dst, "__init__.py"), "a").close()
-
-    if dst_base not in sys.path:
-        sys.path.insert(0, dst_base)
-
-
 ##### Generate dynamic report upon completion of the workflow #####
 
 if config["report"]["generate"]:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -65,17 +65,16 @@ onstart:
     import os, shutil, sys
 
     src = os.path.abspath("scripts")
-    dst = os.path.abspath(os.path.join(".snakemake", "scripts", "scripts"))
+    dst_base = os.path.join(".snakemake", "scripts")
+    dst = os.path.join(dst_base, "scripts")
 
     if os.path.isdir(src):
         shutil.rmtree(dst, ignore_errors=True)
         shutil.copytree(src, dst)
         open(os.path.join(dst, "__init__.py"), "a").close()
 
-    # Add the parent of the copied `scripts` dir to sys.path
-    parent_path = os.path.dirname(dst)
-    if parent_path not in sys.path:
-        sys.path.insert(0, parent_path)
+    if dst_base not in sys.path:
+        sys.path.insert(0, dst_base)
 
 
 ##### Generate dynamic report upon completion of the workflow #####

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -62,13 +62,20 @@ rule all:
 # This is a workaround to be able to import modules from the scripts folder
 # Even when running a snakedeployed workflow
 onstart:
-    import shutil, os
+    import os, shutil, sys
+
     src = os.path.abspath("scripts")
-    dst = os.path.join(".snakemake", "scripts", "scripts")
+    dst = os.path.abspath(os.path.join(".snakemake", "scripts", "scripts"))
+
     if os.path.isdir(src):
         shutil.rmtree(dst, ignore_errors=True)
         shutil.copytree(src, dst)
         open(os.path.join(dst, "__init__.py"), "a").close()
+
+    # Add the parent of the copied `scripts` dir to sys.path
+    parent_path = os.path.dirname(dst)
+    if parent_path not in sys.path:
+        sys.path.insert(0, parent_path)
 
 
 ##### Generate dynamic report upon completion of the workflow #####

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,15 +14,20 @@ report: "report/workflow.rst"
 
 
 include: "rules/common.smk"
-include: "rules/cutadapt.smk"
-include: "rules/pandaseq.smk"
+
 include: "rules/vsearch.smk"
 include: "rules/stats.smk"
 include: "rules/pool_stats.smk"
 include: "rules/parse_fasta.smk"
-include: "rules/process_read_counts.smk"
 
 
+RF_VALS = ["R1"]
+if config["reads"]["paired"]:
+    RF_VALS.append("R2")
+    include: "rules/cutadapt.smk"
+    include: "rules/pandaseq.smk"
+else:
+    include: "rules/cutadapt-se.smk"
 if config["qc"]["perform"]:
     include: "rules/qc.smk"
 
@@ -41,12 +46,29 @@ else:
     raise ValueError(f"Unknown experiment design: {design}")
 
 
+if config["process_read_counts"]:
+    include: "rules/process_read_counts.smk"
+
+
 ##### Target(s) #####
 
 
 rule all:
     input:
         get_target(),
+
+
+##### Copy scripts package into Snakemake folder #####
+# This is a workaround to be able to import modules from the scripts folder
+# Even when running a snakedeployed workflow
+onstart:
+    import shutil, os
+    src = os.path.abspath("scripts")
+    dst = os.path.join(".snakemake", "scripts", "scripts")
+    if os.path.isdir(src):
+        shutil.rmtree(dst, ignore_errors=True)
+        shutil.copytree(src, dst)
+        open(os.path.join(dst, "__init__.py"), "a").close()
 
 
 ##### Generate dynamic report upon completion of the workflow #####
@@ -61,7 +83,23 @@ if config["report"]["generate"]:
             graphs.append(str(qc_path))
     
         if graphs:
-            input_files = " ".join(str(f) for f in graphs)
-            shell(f"snakemake {input_files} --report results/report.html")
+            # Inject config (if specified on the command line)
+            config_arg = None
+            args = sys.argv
+            if "--configfile" in args:
+                idx = args.index("--configfile")
+                if idx + 1 < len(args):
+                    config_arg = args[idx + 1]
+
+            configfile_str = f"--configfile {config_arg}" if config_arg else ""
+
+            report_cmd = (
+                "snakemake "
+                + " ".join(str(f) for f in graphs)
+                + (" " + configfile_str if configfile_str else "")
+                + " --report results/report.html"
+            )
+
+            shell(report_cmd)
         else:
             print(">> No graphs found. Skipping report generation.")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,9 +1,3 @@
-##### Ad-hoc conda apptainer #####
-
-
-containerized: "docker://durr1602/gyoza:latest"
-
-
 ##### Load main report caption #####
 
 
@@ -80,13 +74,7 @@ if config["report"]["generate"]:
 
             configfile_str = f"--configfile {config_arg}" if config_arg else ""
 
-            report_cmd = (
-                "snakemake "
-                + " ".join(str(f) for f in graphs)
-                + (" " + configfile_str if configfile_str else "")
-                + " --report results/report.html"
-            )
-
+            report_cmd = f"snakemake {" ".join(str(f) for f in graphs)}{configfile_str} {" --report results/report.html"}"
             shell(report_cmd)
         else:
             print(">> No graphs found. Skipping report generation.")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -33,7 +33,9 @@ layout_mandatory_cols = [
     "Replicate",
     "Timepoint",
 ]
-layout_csv = pd.read_csv(config["samples"]["path"])
+layout_csv = pd.read_csv(config["samples"]["path"], dtype={"Replicate": str})
+# Sanitize Replicate column
+layout_csv["Replicate"] = layout_csv["Replicate"].fillna("").astype(str).str.strip()
 validate(layout_csv, schema="../schemas/sample_layout.schema.yaml")
 
 # Convert Report column to strict boolean
@@ -100,7 +102,7 @@ if exists(config["samples"]["wt"]):
 # Once the column contains other values than 1 for every row, we'll use the data for normalization
 
 if exists(config["samples"]["generations"]):
-    nbgen = pd.read_csv(config["samples"]["generations"])
+    nbgen = pd.read_csv(config["samples"]["generations"], dtype={"Replicate": str})
     validate(nbgen, schema="../schemas/nbgen.schema.yaml")
     if (config["normalize"]["with_gen"]) & ((nbgen.Nb_gen == 1).all(0)):
         raise Exception(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -212,16 +212,19 @@ def collect_graphs():
     agg_graphs = [
         "rc_filter_plot.svg",
         "unexp_rc_plot.svg",
-        "rc_var_plot.svg",
-        "scoeff_violin_plot.svg",
-        "replicates_heatmap_plot.svg",
-        "replicates_plot.svg",
-        "s_through_time_plot.svg",
-    ]
+    ]    
 
     group_specific_graphs = []
 
     if config["process_read_counts"]:
+        agg_graphs += [
+            "rc_var_plot.svg",
+            "scoeff_violin_plot.svg",
+            "replicates_heatmap_plot.svg",
+            "replicates_plot.svg",
+            "s_through_time_plot.svg",
+        ]
+        
         group_specific_graphs += (
             [f"hist_plot_{k}.svg" for k in REPORTED_GROUPS]
             + [f"upset_plot_{k}.svg" for k in REPORTED_GROUPS]

--- a/workflow/rules/cutadapt-se.smk
+++ b/workflow/rules/cutadapt-se.smk
@@ -1,0 +1,19 @@
+rule cutadapt_se:
+    input:
+        lambda wildcards: f"{READS_PATH}/{sample_layout.loc[wildcards.sample, 'R1']}",
+    params:
+        adapters=lambda wildcards: f"-g {sample_layout.loc[wildcards.sample, 'N_forward']}",
+        extra="-e 0.15 --no-indels --discard-untrimmed",
+    output:
+        touch("logs/2_merge/pandaseq-sample={sample}.stats"),
+        fastq=temp("results/2_merge/{sample}_merged.fasta"),
+        qc="logs/1_trim/cutadapt-sample={sample}.stats",
+    message:
+        "Trimming constant sequences from input file {input[0]}"
+    log:
+        "logs/1_trim/cutadapt-sample={sample}.err",
+    envmodules:
+        # If to be used, update the following, run module avail to see installed modules and versions
+        "cutadapt/5.0",
+    wrapper:
+        "v7.1.0/bio/cutadapt/se"

--- a/workflow/rules/cutadapt.smk
+++ b/workflow/rules/cutadapt.smk
@@ -19,4 +19,4 @@ rule cutadapt:
         # If to be used, update the following, run module avail to see installed modules and versions
         "cutadapt/5.0",
     wrapper:
-        "v5.8.0/bio/cutadapt/pe"
+        "v7.1.0/bio/cutadapt/pe"

--- a/workflow/rules/process_read_counts.smk
+++ b/workflow/rules/process_read_counts.smk
@@ -1,9 +1,12 @@
+readcounts_by_group = {
+    k: [f"results/df/annotated_readcounts/{s}_annot_rc.csv" for s in v]
+    for k, v in grouped_samples_str.items()
+}
+
+
 rule process_read_counts:
     input:
-        readcounts=lambda wildcards: expand(
-            "results/df/annotated_readcounts/{sample}_annot_rc.csv",
-            sample=grouped_samples_str[wildcards.group_key],
-        ),
+        readcounts=lambda wildcards: readcounts_by_group.get(wildcards.group_key, []),
         nbgen=config["samples"]["generations"],
     output:
         selcoeffs="results/df/all_scores_{group_key}.csv",
@@ -51,36 +54,31 @@ rule plot_scores:
         rc_var_plot=report(
             "results/graphs/rc_var_plot.svg",
             "../report/rc_var_plot.rst",
-            category="2. Read processing",
-            subcategory="Aggregated",
+            category="2. Read processing (all groups)",
             labels={"figure": "2.3. Distribution of allele frequencies"},
         ),
         scoeff_violin_plot=report(
             "results/graphs/scoeff_violin_plot.svg",
             "../report/scoeff_violin_plot.rst",
-            category="3. Functional impact",
-            subcategory="Aggregated",
+            category="3. Functional impact (all groups)",
             labels={"figure": "3.1. Distribution of functional impact scores"},
         ),
         replicates_heatmap_plot=report(
             "results/graphs/replicates_heatmap_plot.svg",
             "../report/replicates_heatmap_plot.rst",
-            category="3. Functional impact",
-            subcategory="Aggregated",
+            category="3. Functional impact (all groups)",
             labels={"figure": "3.2. Correlation between replicates (1/2)"},
         ),
         replicates_plot=report(
             "results/graphs/replicates_plot.svg",
             "../report/replicates_plot.rst",
-            category="3. Functional impact",
-            subcategory="Aggregated",
+            category="3. Functional impact (all groups)",
             labels={"figure": "3.3. Correlation between replicates (2/2)"},
         ),
         s_through_time_plot=report(
             "results/graphs/s_through_time_plot.svg",
             "../report/s_through_time_plot.rst",
-            category="3. Functional impact",
-            subcategory="Aggregated",
+            category="3. Functional impact (all groups)",
             labels={"figure": "3.4. Functional impact over time"},
         ),
     message:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -26,7 +26,7 @@ rule fastqc:
 
 rule multiqc:
     input:
-        expand("results/0_qc/{sample}_{RF}_fastqc.zip", sample=SAMPLES, RF=["R1", "R2"]),
+        expand("results/0_qc/{sample}_{RF}_fastqc.zip", sample=SAMPLES, RF=RF_VALS),
     output:
         report(
             "results/0_qc/multiqc.html",

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -1,8 +1,8 @@
 rule stats:
     input:
-        cutadapt_log=rules.cutadapt.output.qc,
-        pandaseq_log=rules.pandaseq.log,
-        vsearch_log=rules.vsearch_fastx_uniques.log,
+        cutadapt_log="logs/1_trim/cutadapt-sample={sample}.stats",
+        pandaseq_log="logs/2_merge/pandaseq-sample={sample}.stats",
+        vsearch_log="logs/3_aggregate/vsearch-sample={sample}.stats",
     output:
         "results/stats/stats-sample={sample}.csv",
     message:

--- a/workflow/rules/vsearch.smk
+++ b/workflow/rules/vsearch.smk
@@ -1,6 +1,6 @@
 rule vsearch_fastx_uniques:
     input:
-        fastx_uniques=rules.pandaseq.output,
+        fastx_uniques="results/2_merge/{sample}_merged.fasta",
     output:
         fastaout=temp("results/3_aggregate/{sample}_aggregated.fasta"),
     message:

--- a/workflow/schemas/nbgen.schema.yaml
+++ b/workflow/schemas/nbgen.schema.yaml
@@ -7,6 +7,7 @@ type: object
 properties:
   Replicate:
     type: string
+    minLength: 1
     description: Replicate (e.g. cultured in two separate tubes with the same set of conditions)
   Timepoint:
     type: string

--- a/workflow/schemas/sample_layout.schema.yaml
+++ b/workflow/schemas/sample_layout.schema.yaml
@@ -34,14 +34,13 @@ properties:
     description: Replicate (e.g. cultured in two separate tubes with the same set of conditions)
   Timepoint:
     type: string
+    minLength: 1
     description: Time point (mandatory are T0 and at least one other time point, e.g. T1)
 
 required:
   - Sample_name
   - R1
-  - R2
   - N_forward
-  - N_reverse
   - Mutated_seq
   - Pos_start
   - Replicate

--- a/workflow/scripts/annotate_mutants.py
+++ b/workflow/scripts/annotate_mutants.py
@@ -1,6 +1,126 @@
 from snakemake.script import snakemake
-from my_functions import load_codon_dic, annotate_mutants
+
+# from scripts.my_functions import load_codon_dic, annotate_mutants
 import pandas as pd
+
+
+def load_codon_dic(table):
+    """
+    Small function to load the codon table and return a dictionary
+    """
+    codon_table = pd.read_csv(table, header=0)
+    codon_table["codon"] = codon_table["codon"].str.upper()
+    codon_dic = dict(zip(codon_table["codon"], codon_table["aminoacid"]))
+    return codon_dic
+
+
+def get_mutations(seq, wt, codon_dic):
+    """
+    By comparing a mutated DNA sequence to the wild-type sequence,
+    this function returns the mutations (if there are any).
+    Mutations are formatted as # mutated codon / position / alternative codon / alternative amino acid
+    in lists with matching indexes to be able to quickly convert to 1 row per mutation per mutated codon
+    The alternative and corresponding wild-type codons are translated into their corresponding amino acid using the provided codon table dictionary
+    From there, we also calculate the Hamming distances in codons, nucleotides and amino acids.
+    """
+    if len(seq) != len(wt):
+        raise ValueError(
+            f"Error.. Cannot annotate expected mutants because at least one sequence is of different length than wild-type."
+        )
+
+    if len(seq) % 3 != 0:
+        raise ValueError(
+            f"Error.. the length of the DNA sequence is not a multiple of 3."
+        )
+
+    VALID_BASES = {"A", "C", "G", "T"}
+
+    if not set(seq).issubset(VALID_BASES):
+        raise ValueError(
+            f"Error.. one of the provided nucleotide sequences contains an unrecognized character."
+        )
+
+    is_wt = seq == wt
+
+    list_alt_pos, list_alt_cod, list_alt_aa, list_aa = [], [], [], []
+    Nham_nt = 0
+    Nham_aa = 0
+
+    wt_codons = [
+        wt[i : i + 3]
+        for i in range(
+            0, len(wt), 3
+        )  # Converting WT nucleotide sequence to list of codons
+    ]
+    seq_codons = [
+        seq[i : i + 3]
+        for i in range(
+            0, len(seq), 3
+        )  # Converting nucleotide sequence of variant to list of codons
+    ]
+
+    for i, (wtc, c) in enumerate(zip(wt_codons, seq_codons)):  # Loop through codons
+        alt_aa = codon_dic.get(c)
+        wt_aa = codon_dic.get(wtc)
+        list_aa.append(alt_aa)
+        if c != wtc:
+            list_alt_pos.append(i)
+            list_alt_cod.append(c)
+            list_alt_aa.append(alt_aa)
+            Nham_nt += (wtc != c) * sum(
+                x != y for x, y in zip(wtc, c)  # Calls zip only when codons differ
+            )
+            if alt_aa != wt_aa:
+                Nham_aa += 1
+
+    Nham_codons = len(list_alt_pos)
+
+    if Nham_codons > 0:
+        mut_codons = list(range(1, Nham_codons + 1))
+    else:
+        mut_codons = [0]
+        list_alt_pos = ["not-applicable"]
+        list_alt_cod = ["not-applicable"]
+        list_alt_aa = ["not-applicable"]
+
+    aa_seq = "".join(list_aa)
+
+    return (
+        is_wt,
+        aa_seq,
+        Nham_codons,
+        Nham_nt,
+        Nham_aa,
+        mut_codons,
+        list_alt_pos,
+        list_alt_cod,
+        list_alt_aa,
+    )
+
+
+def annotate_mutants(df, codon_dic):
+    """
+    Processes subdataframes with at least two columns (nt_seq and WT_seq)
+    Compares both and returns mutations with a custom function
+    Outputs corresponding subdataframe with annotated mutations
+    """
+    per_seq_cols = ["WT", "aa_seq", "Nham_codons", "Nham_nt", "Nham_aa"]
+    per_mut_cols = ["mutated_codon", "pos", "alt_codons", "alt_aa"]
+    new_cols = per_seq_cols + per_mut_cols
+
+    # Making sure sequences are capitalized
+    df["nt_seq"] = df["nt_seq"].str.upper()
+    df["WT_seq"] = df["WT_seq"].str.upper()
+
+    collected_mutations = [
+        get_mutations(seq, wt, codon_dic) for seq, wt in zip(df["nt_seq"], df["WT_seq"])
+    ]
+
+    mutations_dict = dict(zip(new_cols, zip(*collected_mutations)))
+    df = df.assign(**mutations_dict)
+    df = df.explode(per_mut_cols).reset_index(drop=True)
+
+    return df
 
 
 def get_annotated_mutants(mut_path, outpath, indel_outpath, codon_table):

--- a/workflow/scripts/annotate_mutants.py
+++ b/workflow/scripts/annotate_mutants.py
@@ -1,3 +1,7 @@
+import sys
+print("=== sys.path ===")
+for p in sys.path:
+    print(p)
 from snakemake.script import snakemake
 from scripts.my_functions import load_codon_dic, annotate_mutants
 import pandas as pd

--- a/workflow/scripts/annotate_mutants.py
+++ b/workflow/scripts/annotate_mutants.py
@@ -1,9 +1,5 @@
-import sys
-print("=== sys.path ===")
-for p in sys.path:
-    print(p)
 from snakemake.script import snakemake
-from scripts.my_functions import load_codon_dic, annotate_mutants
+from my_functions import load_codon_dic, annotate_mutants
 import pandas as pd
 
 

--- a/workflow/scripts/annotate_mutants.py
+++ b/workflow/scripts/annotate_mutants.py
@@ -1,5 +1,12 @@
+import sys, os
+
+# Inject correct path
+workflow_dir = os.path.dirname(os.path.dirname(__file__))
+scripts_dir = os.path.join(workflow_dir, "scripts")
+sys.path.insert(0, scripts_dir)
+
 from snakemake.script import snakemake
-from scripts.my_functions import load_codon_dic, annotate_mutants
+from my_functions import load_codon_dic, annotate_mutants
 import pandas as pd
 
 

--- a/workflow/scripts/annotate_mutants.py
+++ b/workflow/scripts/annotate_mutants.py
@@ -1,12 +1,5 @@
-import sys, os
-
-# Inject correct path
-workflow_dir = os.path.dirname(os.path.dirname(__file__))
-scripts_dir = os.path.join(workflow_dir, "scripts")
-sys.path.insert(0, scripts_dir)
-
 from snakemake.script import snakemake
-from my_functions import load_codon_dic, annotate_mutants
+from scripts.my_functions import load_codon_dic, annotate_mutants
 import pandas as pd
 
 

--- a/workflow/scripts/generate_mutants.py
+++ b/workflow/scripts/generate_mutants.py
@@ -1,7 +1,12 @@
-from snakemake.script import snakemake
-from scripts.my_functions import load_codon_dic, get_single_double, get_nt_seq
+import sys, os
 
-# from pathlib import Path
+# Inject correct path
+workflow_dir = os.path.dirname(os.path.dirname(__file__))
+scripts_dir = os.path.join(workflow_dir, "scripts")
+sys.path.insert(0, scripts_dir)
+
+from snakemake.script import snakemake
+from my_functions import load_codon_dic, get_single_double, get_nt_seq
 import pandas as pd
 import itertools
 

--- a/workflow/scripts/generate_mutants.py
+++ b/workflow/scripts/generate_mutants.py
@@ -1,12 +1,5 @@
-import sys, os
-
-# Inject correct path
-workflow_dir = os.path.dirname(os.path.dirname(__file__))
-scripts_dir = os.path.join(workflow_dir, "scripts")
-sys.path.insert(0, scripts_dir)
-
 from snakemake.script import snakemake
-from my_functions import load_codon_dic, get_single_double, get_nt_seq
+from scripts.my_functions import load_codon_dic, get_single_double, get_nt_seq
 import pandas as pd
 import itertools
 

--- a/workflow/scripts/generate_mutants.py
+++ b/workflow/scripts/generate_mutants.py
@@ -1,7 +1,152 @@
 from snakemake.script import snakemake
-from scripts.my_functions import load_codon_dic, get_single_double, get_nt_seq
+
+# from scripts.my_functions import load_codon_dic, get_single_double, get_nt_seq
 import pandas as pd
+import numpy as np
 import itertools
+
+
+def load_codon_dic(table):
+    """
+    Small function to load the codon table and return a dictionary
+    """
+    codon_table = pd.read_csv(table, header=0)
+    codon_table["codon"] = codon_table["codon"].str.upper()
+    codon_dic = dict(zip(codon_table["codon"], codon_table["aminoacid"]))
+    return codon_dic
+
+
+def get_alt_codons(seq, codon_dic, mode="NNN"):
+    """
+    Based on a DNA sequence, the function returns two lists:
+    1) A list containing all 0-based amino acid positions for the sequence
+    2) A list containing all possible alternative codons (other than WT codon) at the matching positions
+    For list 2, the mode defines which codons are acceptable: NNN by default, or NNK
+    Codons are fetched in the provided codon table (dictionary)
+    """
+
+    if mode == "NNN":
+        alt = [x for x in codon_dic.keys()]
+    elif mode == "NNK":
+        alt = [x for x in codon_dic.keys() if x[2] in ["G", "T"]]
+    else:
+        print("Pleae specify a correct mode: either NNN or NNK")
+
+    pos_l = []
+    var_l = []
+
+    for i in range(0, len(seq), 3):
+        list_var = [x for x in alt if x != seq[i : i + 3]]
+        pos_l.append(i // 3)  # 0-based position (aa)
+        var_l.append(list_var)  # list of possible codons other than WT
+
+
+def get_single_double(df, codon_dic, codon_mode):
+    """
+    Processes a minimal dataframe containing the wild-type nucleotide sequence to mutate.
+    From the codon_mode, generates all single mutants and optionally double mutants.
+    Returns dataframe in long format (one row per mutated codon).
+    """
+    if codon_mode not in ["NNN", "NNK", "NNN x NNN", "NNK x NNK"]:
+        raise Exception(f"Error.. check the codon mode specified in the config.")
+    elif codon_mode in ["NNN", "NNK"]:
+        single_codon_mode = codon_mode
+    else:
+        single_codon_mode = codon_mode.split(" x ")[0]
+
+    singles_compact = df.copy()
+    singles_compact["pos"], singles_compact["alt_codons"] = zip(
+        *singles_compact.WT_seq.apply(
+            lambda x: get_alt_codons(x, codon_dic, single_codon_mode)
+        )
+    )
+
+    singles_compact = singles_compact.explode(["pos", "alt_codons"])
+    singles_df = singles_compact.explode("alt_codons")
+    singles_df["mutations"] = singles_df.apply(
+        lambda row: {row[f"pos"]: row[f"alt_codons"]}, axis=1
+    )
+
+    if codon_mode in ["NNN x NNN", "NNK x NNK"]:
+        pairwise_df = df.copy()
+
+        # Get pairwise combinations of codons that will be mutated
+        pairwise_df["combination"] = pairwise_df.WT_seq.apply(
+            lambda x: [
+                x
+                for x in list(itertools.combinations(range(0, len(x) // 3), 2))
+                for _ in range(2)
+            ]
+        )
+        doubles_compact_df = pairwise_df.explode("combination")
+        doubles_compact_df["mutated_codon"] = np.tile(
+            [1, 2], len(doubles_compact_df) // 2 + 1
+        )[: len(doubles_compact_df)]
+        doubles_compact_df["pos"] = doubles_compact_df.apply(
+            lambda row: row.combination[row.mutated_codon - 1], axis=1
+        )
+
+        # Build a lookup dictionary for alternative codons at each position
+        # We use the previously built dataframe
+        alt_lookup = singles_df.groupby("pos")["alt_codons"].unique().to_dict()
+
+        # Leverage dictionary to map alternative codons at each position
+        doubles_compact_df["alt_codons"] = doubles_compact_df["pos"].map(alt_lookup)
+
+        # Dataframe is pivoted only to be able to use pd.explode(), then later on melted to go back to long format
+        doubles_piv = doubles_compact_df.pivot_table(
+            index=["Mutated_seq", "WT_seq", "combination"],
+            columns="mutated_codon",
+            values=["pos", "alt_codons"],
+            aggfunc="first",
+        ).reset_index()
+        doubles_piv.columns = [x[0] for x in doubles_piv.columns[:-4]] + [
+            f"{x[0]}{x[1]}" for x in doubles_piv.columns[-4:]
+        ]
+
+        # Reshape
+        doubles_exp1 = doubles_piv.explode("alt_codons1")
+        doubles_exp2 = doubles_exp1.explode("alt_codons2")
+        doubles_df = doubles_exp2.reset_index(drop=True)
+
+        # Create dictionary of mutations, here we go with numpy to be as efficient as possible, even with very large datasets
+        keys = np.stack([doubles_df["pos1"].values, doubles_df["pos2"].values], axis=1)
+        vals = np.stack(
+            [doubles_df["alt_codons1"].values, doubles_df["alt_codons2"].values], axis=1
+        )
+        doubles_df["mutations"] = [dict(zip(k, v)) for k, v in zip(keys, vals)]
+        doubles_df.drop(
+            ["pos1", "pos2", "alt_codons1", "alt_codons2", "combination"],
+            axis=1,
+            inplace=True,
+        )
+
+    else:
+        doubles_df = pd.DataFrame()
+
+    # Concatenate dataframes for single mutants (and double mutants if there are any)
+    mutants_df = pd.concat(
+        [singles_df.drop(["pos", "alt_codons"], axis=1), doubles_df], ignore_index=True
+    )
+
+    return mutants_df
+
+
+def get_nt_seq(seq, mut_dic):
+    """
+    Reconstitutes a nucleotide sequence based on a dictionary of mutations,
+    containing positions and alternative codons.
+    """
+    list_codons = [
+        seq[i : i + 3]
+        for i in range(0, len(seq), 3)  # Convert nucleotide sequence to list of codons
+    ]
+
+    for pos, mut_codon in mut_dic.items():
+        if 0 <= pos < len(list_codons):
+            list_codons[pos] = mut_codon
+
+    return "".join(list_codons)
 
 
 def generate_mutants(wtseq_path, outpath, codon_table, codon_mode):

--- a/workflow/scripts/plot_scores.py
+++ b/workflow/scripts/plot_scores.py
@@ -1,4 +1,6 @@
 from snakemake.script import snakemake
+
+"""
 from scripts.my_functions import concatenate_df
 from scripts.plotting_functions import (
     plot_allele_freq,
@@ -7,7 +9,16 @@ from scripts.plotting_functions import (
     plot_spearman_heatmaps,
     plot_replicate_scatter,
 )
+"""
 import pandas as pd
+from scipy import stats
+import seaborn as sns
+import matplotlib
+
+matplotlib.use("Agg")  # Non-GUI backend for generating plots without display
+import matplotlib.pyplot as plt
+
+plt.rcParams["svg.fonttype"] = "none"
 
 mutation_attributes_aa = [
     "mutated_codon",
@@ -18,12 +29,209 @@ mutation_attributes_aa = [
 ]
 
 
+def concatenate_df(df_files):
+    """
+    Takes list of paths to dataframes as input.
+    Returns single concatenated dataframe.
+    """
+    list_df = []
+    for f in df_files:
+        list_df.append(pd.read_csv(f))
+    df = pd.concat(list_df, ignore_index=True)
+    return df
+
+
+def plot_allele_freq(df, outpath, mean_exp_freq, plot_formats):
+    """
+    Plots distributions of allele frequencies for each sample group.
+    Sample groups must be in column "Sample attributes".
+    Replicates are shown as split violins.
+    """
+    labels = df["Sample attributes"].unique()
+    timepoints = sorted(df.Timepoint.unique())
+    g = sns.catplot(
+        df,
+        x="Sample attributes",
+        y="frequency",
+        row="Timepoint",
+        row_order=timepoints,
+        hue="Replicate",
+        palette="hls",
+        split=True,  # should work for more than 2 samples but might be ugly
+        log_scale=10,
+        kind="violin",
+        cut=0,
+        linewidth=1,
+        inner="quart",
+        height=2,
+        aspect=0.8 * len(labels),
+    )
+    g.map(plt.axhline, y=10**mean_exp_freq, linestyle="--", color=".8")
+
+    g.set_axis_labels("", "Frequency")
+    g.set_titles(row_template="{row_name}")
+    g.set_xticklabels(labels, rotation=45, ha="right")
+    g.tight_layout()
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
 def get_allele_freq_plot(df_files, outpath, plot_formats):
     df = concatenate_df(df_files)
     mean_exp_freq = (
         df.groupby("Sample attributes")[["Mean_exp_freq"]].first().mean(axis=None)
     )
     plot_allele_freq(df, outpath, mean_exp_freq, plot_formats)
+    return
+
+
+def plot_scoeff_violin(df, outpath, plot_formats):
+    """
+    Plots distributions of functional impact scores for each sample group.
+    Sample groups must be in column "Sample attributes".
+    Replicates are shown as split violins.
+    """
+    labels = df["Sample attributes"].unique()
+    timepoints = sorted(df["Compared timepoints"].unique())
+    g = sns.catplot(
+        df,
+        x="Sample attributes",
+        y="s",
+        row="Compared timepoints",
+        row_order=timepoints,
+        hue="Replicate",
+        palette="hls",
+        split=True,  # should work for more than 2 samples but might be ugly
+        kind="violin",
+        cut=0,
+        linewidth=1,
+        inner="quart",
+        height=2,
+        aspect=0.8 * len(labels),
+    )
+
+    g.set_axis_labels("", "s")
+    g.set_titles(row_template="{row_name}")
+    g.set_xticklabels(labels, rotation=45, ha="right")
+    g.tight_layout()
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_impact_over_time(df, outpath, plot_formats):
+    """
+    Plots functional impact over time for each sample group.
+    Sample groups must be in column "Sample attributes".
+    Bands indicate spread (standard deviation) for each mutation type.
+    """
+    g = sns.relplot(
+        data=df,
+        x="Compared timepoints",
+        y="s",
+        col="Sample attributes",
+        col_wrap=3,
+        hue="mutation_type",
+        palette="hls",
+        style="Replicate",
+        kind="line",
+        markers=True,
+        errorbar="sd",
+        height=1.5,
+    )
+    g.set(xlabel="")
+    g.set_titles(col_template="{col_name}")
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_spearman_heatmaps(df, replicates, outpath, plot_formats):
+    """
+    Plots heatmaps with Spearman correlation coefficient,
+    for each pairwise comparison between replicates,
+    for each sample group.
+    Sample groups must be in column "Sample attributes".
+    """
+    labels = df["Sample attributes"].unique()
+    timepoints = sorted(df["Compared timepoints"].unique())
+    g = sns.FacetGrid(
+        df,
+        col="Sample attributes",
+        col_order=labels,
+        row="Compared timepoints",
+        row_order=timepoints,
+    )
+    g.set_titles(col_template="{col_name}", row_template="{row_name}")
+
+    for i, t in enumerate(timepoints):
+        for j, l in enumerate(labels):
+            yl = []
+            for y in replicates:
+                xl = []
+                for x in replicates:
+                    xval = df[
+                        (df["Sample attributes"] == l)
+                        & (df["Compared timepoints"] == t)
+                    ][x].values
+                    yval = df[
+                        (df["Sample attributes"] == l)
+                        & (df["Compared timepoints"] == t)
+                    ][y].values
+                    spearmanr, sp = stats.spearmanr(xval, yval)
+                    xl.append(spearmanr)
+                yl.append(xl)
+            spearmanwide = pd.DataFrame(yl, columns=replicates, index=replicates)
+            sns.heatmap(
+                spearmanwide,
+                vmin=0.5,
+                vmax=1,
+                cmap="viridis_r",
+                annot=True,
+                fmt=".2f",
+                ax=g.axes[i][j],
+            )
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_replicate_scatter(df, replicates, outpath, plot_formats):
+    """
+    Plots correlation between first two replicates, for each sample group.
+    replicates argument = list with values corresponding to each replicate.
+    Sample groups must be in column "Sample attributes".
+    """
+    g = sns.lmplot(
+        df,
+        x=replicates[0],
+        y=replicates[1],
+        col="Sample attributes",
+        col_wrap=3,
+        hue="Compared timepoints",
+        palette="mako",
+        height=1.5,
+        scatter_kws={"s": 8, "alpha": 0.2},
+    )
+    g.set_titles(col_template="{col_name}")
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
     return
 
 

--- a/workflow/scripts/plot_scores.py
+++ b/workflow/scripts/plot_scores.py
@@ -1,13 +1,6 @@
-import sys, os
-
-# Inject correct path
-workflow_dir = os.path.dirname(os.path.dirname(__file__))
-scripts_dir = os.path.join(workflow_dir, "scripts")
-sys.path.insert(0, scripts_dir)
-
 from snakemake.script import snakemake
-from my_functions import concatenate_df
-from plotting_functions import (
+from scripts.my_functions import concatenate_df
+from scripts.plotting_functions import (
     plot_allele_freq,
     plot_scoeff_violin,
     plot_impact_over_time,
@@ -43,6 +36,7 @@ def get_s_plots(
     plot_formats,
 ):
     df = concatenate_df(df_files)
+    df["Replicate"] = df["Replicate"].astype(str)
     plot_scoeff_violin(df, scoeff_plot_outpath, plot_formats)
     plot_impact_over_time(df, s_time_plot_outpath, plot_formats)
 

--- a/workflow/scripts/plot_scores.py
+++ b/workflow/scripts/plot_scores.py
@@ -1,6 +1,13 @@
+import sys, os
+
+# Inject correct path
+workflow_dir = os.path.dirname(os.path.dirname(__file__))
+scripts_dir = os.path.join(workflow_dir, "scripts")
+sys.path.insert(0, scripts_dir)
+
 from snakemake.script import snakemake
-from scripts.my_functions import concatenate_df
-from scripts.plotting_functions import (
+from my_functions import concatenate_df
+from plotting_functions import (
     plot_allele_freq,
     plot_scoeff_violin,
     plot_impact_over_time,

--- a/workflow/scripts/plotting_functions.py
+++ b/workflow/scripts/plotting_functions.py
@@ -172,17 +172,23 @@ def plot_timepoint_corr(df, outpath, sample_group, plot_formats):
     Plots pairwise comparisons of selection coefficients
     to look at correlation between time points.
     """
-    g = sns.pairplot(
-        df,
-        hue="confidence_score",
-        hue_order=CSCORES,
-        palette=dict(zip(CSCORES, CSCORE_COLORS)),
-        plot_kws={"s": 8, "alpha": 0.2},
-        height=1.5,
-        corner=True,
-    )
-    g.tight_layout()
-    plt.subplots_adjust(top=0.9)
+    # Check number of columns
+    if len([x for x in df.columns if x != "confidence_score"]) <= 1:
+        f, ax = plt.subplots(figsize=(4, 4))
+        ax.text(0.5, 0.5, "Not enough time points to plot", ha="center", va="center")
+        ax.set_axis_off()  # hide axes
+    else:
+        g = sns.pairplot(
+            df,
+            hue="confidence_score",
+            hue_order=CSCORES,
+            palette=dict(zip(CSCORES, CSCORE_COLORS)),
+            plot_kws={"s": 8, "alpha": 0.2},
+            height=1.5,
+            corner=True,
+        )
+        g.tight_layout()
+        plt.subplots_adjust(top=0.9)
     plt.suptitle(f"Samples attributes: {sample_group}")
 
     plt.savefig(outpath, format="svg", dpi=300)

--- a/workflow/scripts/plotting_functions.py
+++ b/workflow/scripts/plotting_functions.py
@@ -2,6 +2,9 @@ import pandas as pd
 import numpy as np
 from scipy import stats
 import seaborn as sns
+import matplotlib
+
+matplotlib.use("Agg")  # Non-GUI backend for generating plots without display
 import matplotlib.pyplot as plt
 
 plt.rcParams["svg.fonttype"] = "none"

--- a/workflow/scripts/pool_stats.py
+++ b/workflow/scripts/pool_stats.py
@@ -1,12 +1,5 @@
-import sys, os
-
-# Inject correct path
-workflow_dir = os.path.dirname(os.path.dirname(__file__))
-scripts_dir = os.path.join(workflow_dir, "scripts")
-sys.path.insert(0, scripts_dir)
-
 from snakemake.script import snakemake
-from plotting_functions import plot_stacked_barplot, plot_unexp_plot
+from scripts.plotting_functions import plot_stacked_barplot, plot_unexp_plot
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt

--- a/workflow/scripts/pool_stats.py
+++ b/workflow/scripts/pool_stats.py
@@ -1,6 +1,82 @@
 from snakemake.script import snakemake
-from scripts.plotting_functions import plot_stacked_barplot, plot_unexp_plot
+
+# from scripts.plotting_functions import plot_stacked_barplot, plot_unexp_plot
 import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib
+
+matplotlib.use("Agg")  # Non-GUI backend for generating plots without display
+import matplotlib.pyplot as plt
+
+plt.rcParams["svg.fonttype"] = "none"
+
+
+def plot_stacked_barplot(df, outpath, exp_rc_per_sample, plot_formats):
+    samples = df["Sample_name"].to_list()
+    width = 0.5
+    color_dict = dict(
+        zip(
+            ["OK", "Trimming", "Merging", "Aggregating", "Unexpected"],
+            sns.color_palette("Spectral_r", 6)[1:],
+        )
+    )
+
+    f, ax = plt.subplots(figsize=(20, 5))
+    bottom = np.zeros(len(df))
+
+    for l in color_dict.keys():
+        p = ax.bar(
+            samples,
+            df[l].values,
+            width,
+            label=l,
+            bottom=bottom,
+            color=color_dict[l],
+        )
+        bottom += df[l].values
+
+    ax.set_yscale("log", base=10)
+    ax.set(ylim=(1e4, 1e7), ylabel="Read count")
+
+    ax.axhline(y=exp_rc_per_sample, linestyle="--", color=".8")
+    ax.annotate("Aim", (-4, 1.1 * exp_rc_per_sample), color=".5")
+
+    ax.xaxis.set_ticks(samples)
+    ax.set_xticklabels(samples, rotation=45, ha="right")
+    ax.legend(framealpha=0.9)
+
+    plt.tight_layout()
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_unexp_plot(df, outpath, plot_formats):
+    # Empty plot if empty dataframe
+    if df.empty:
+        f, ax = plt.subplots(figsize=(4, 4))
+        ax.text(0.5, 0.5, "No unexpected sequences", ha="center", va="center")
+        ax.set_axis_off()  # hide axes
+    else:
+        sns.kdeplot(
+            data=df,
+            x="readcount",
+            hue="Sample_name",
+            common_norm=False,
+            log_scale=True,
+            legend=False,
+        )
+        plt.xlabel("Read count of unexpected variants")
+        plt.savefig(outpath, format="svg", dpi=300)
+        [
+            plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+            for x in plot_formats
+        ]
+    return
 
 
 def get_pooled_stats(

--- a/workflow/scripts/pool_stats.py
+++ b/workflow/scripts/pool_stats.py
@@ -1,10 +1,6 @@
 from snakemake.script import snakemake
 from scripts.plotting_functions import plot_stacked_barplot, plot_unexp_plot
 import pandas as pd
-import seaborn as sns
-import matplotlib.pyplot as plt
-
-plt.rcParams["svg.fonttype"] = "none"
 
 
 def get_pooled_stats(

--- a/workflow/scripts/pool_stats.py
+++ b/workflow/scripts/pool_stats.py
@@ -1,5 +1,12 @@
+import sys, os
+
+# Inject correct path
+workflow_dir = os.path.dirname(os.path.dirname(__file__))
+scripts_dir = os.path.join(workflow_dir, "scripts")
+sys.path.insert(0, scripts_dir)
+
 from snakemake.script import snakemake
-from scripts.plotting_functions import plot_stacked_barplot, plot_unexp_plot
+from plotting_functions import plot_stacked_barplot, plot_unexp_plot
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt

--- a/workflow/scripts/process_rc.py
+++ b/workflow/scripts/process_rc.py
@@ -1,13 +1,171 @@
 from snakemake.script import snakemake
+
+"""
 from scripts.my_functions import get_confidence_score, get_mutation_type
 from scripts.plotting_functions import (
     plot_rc_per_seq,
     plot_upset_TR,
     plot_timepoint_corr,
 )
+"""
 import pandas as pd
 import numpy as np
+import seaborn as sns
+import matplotlib
+
+matplotlib.use("Agg")  # Non-GUI backend for generating plots without display
+import matplotlib.pyplot as plt
+
+plt.rcParams["svg.fonttype"] = "none"
+from upsetplot import from_indicators
+from upsetplot import UpSet
 import warnings
+
+CSCORES = [1, 2, 3]
+CSCORE_COLORS = ["green", "orange", "red"]
+
+
+def get_confidence_score(g, threshold):
+    """
+    Labels variants with a confidence score based on read count at T0
+    """
+    if (g >= threshold).all():  # Above threshold in all replicates
+        return 1  # best confidence score
+    elif (g >= threshold).any():  # Above threshold in at least 1 replicate
+        return 2  # medium confidence score
+    else:
+        return 3  # low confidence score
+
+
+def get_mutation_type(Nham_aa, alt_aa):
+    """
+    Quick function to determine if the mutation is silent or non-synonymous
+    and if it's missense or nonsense
+    """
+    if Nham_aa == 0:
+        return "silent"
+    elif alt_aa == "*":
+        return "nonsense"
+    else:
+        return "missense"
+
+
+def plot_rc_per_seq(
+    df1, df2, outpath, sample_group, exp_rc_per_var, mean_exp_freq, plot_formats
+):
+    """
+    Expects a dataframe of raw read counts and
+    equivalent converted into read frequencies
+    (normalized with sample depth).
+    """
+    fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(10, 4))
+
+    sns.histplot(df1, element="step", bins=50, common_norm=False, log_scale=10, ax=ax1)
+    ax1.axvline(x=exp_rc_per_var, linestyle="--", color=".8")
+    ax1.set(xlabel="Raw read count")
+
+    sns.histplot(df2, element="step", bins=50, log_scale=10, common_norm=False, ax=ax2)
+    ax2.axvline(x=10**mean_exp_freq, linestyle="--", color=".8")
+    ax2.set(xlabel="Frequency")
+
+    plt.subplots_adjust(top=0.9)
+    plt.suptitle(f"Samples attributes: {sample_group}")
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_upset_TR(df, conditions, outpath, sample_group, plot_formats):
+    """
+    Plots overlap across time points and replicates
+    in the form of an upsetplot, counting the number of unique sequences.
+    Conditions argument correspond to columns in the dataframe..
+    ..should be boolean and indicate whether or not the sequence is in the
+    combination of time point/replicate
+    """
+    fig = plt.figure(figsize=(6, 6))
+    upset_obj = UpSet(
+        from_indicators(conditions, data=df),
+        # show_percentages=True,
+        show_counts=True,
+        min_subset_size="1%",
+        sort_by="cardinality",
+        element_size=None,
+        intersection_plot_elements=0,  # height of intersection barplot in matrix elements
+        totals_plot_elements=2,  # width of totals barplot in matrix elements
+    )
+
+    upset_obj.add_stacked_bars(
+        by="confidence_score", colors=dict(zip(CSCORES, CSCORE_COLORS)), elements=3
+    )
+
+    upset_obj.add_catplot(
+        value="mean_input",
+        kind="violin",
+        cut=0,
+        density_norm="count",
+        log_scale=10,
+        linewidth=0.5,
+        elements=3,  # height in number of matrix elements
+    )
+
+    d = upset_obj.plot(
+        fig=fig
+    )  # Assigns all plots to a dictionary containing axes subplots - same keys as gridspec returned by upset_obj.make_grid()
+    ax0 = d[
+        "extra0"  # Key corresponding to 1st stacked barplot - confidence score ('intersections' = intersection barplot)
+    ]
+    ax1 = d["extra1"]  # Key corresponding to 1st catplot - read count for input samples
+
+    ax0.set_ylabel("# Variants")
+    ax0.legend(title="Confidence score")
+
+    ax1.set_ylabel("Mean\nT0 freq.")
+
+    plt.subplots_adjust(top=0.95)
+    plt.suptitle(f"Samples attributes: {sample_group}")
+
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
+
+
+def plot_timepoint_corr(df, outpath, sample_group, plot_formats):
+    """
+    Plots pairwise comparisons of selection coefficients
+    to look at correlation between time points.
+    """
+    # Check number of columns
+    if len([x for x in df.columns if x != "confidence_score"]) <= 1:
+        f, ax = plt.subplots(figsize=(4, 4))
+        ax.text(0.5, 0.5, "Not enough time points to plot", ha="center", va="center")
+        ax.set_axis_off()  # hide axes
+    else:
+        g = sns.pairplot(
+            df,
+            hue="confidence_score",
+            hue_order=CSCORES,
+            palette=dict(zip(CSCORES, CSCORE_COLORS)),
+            plot_kws={"s": 8, "alpha": 0.2},
+            height=1.5,
+            corner=True,
+        )
+        g.tight_layout()
+        plt.subplots_adjust(top=0.9)
+    plt.suptitle(f"Samples attributes: {sample_group}")
+
+    plt.savefig(outpath, format="svg", dpi=300)
+    [
+        plt.savefig(f"{outpath.split('.svg')[0]}.{x}", format=x, dpi=300)
+        for x in plot_formats
+    ]
+    return
 
 
 def get_selcoeffs(

--- a/workflow/scripts/process_rc.py
+++ b/workflow/scripts/process_rc.py
@@ -1,6 +1,13 @@
+import sys, os
+
+# Inject correct path
+workflow_dir = os.path.dirname(os.path.dirname(__file__))
+scripts_dir = os.path.join(workflow_dir, "scripts")
+sys.path.insert(0, scripts_dir)
+
 from snakemake.script import snakemake
-from scripts.my_functions import get_confidence_score, get_mutation_type
-from scripts.plotting_functions import (
+from my_functions import get_confidence_score, get_mutation_type
+from plotting_functions import (
     plot_rc_per_seq,
     plot_upset_TR,
     plot_timepoint_corr,


### PR DESCRIPTION
Major:
- now supports single-end sequencing data
- process_read_counts now optional (get your read counts from any experiment!)
- flattened scripts to solve an import module import error which prevented deployment with snakedeploy

Minor:
- config file can be specified on the command line
- upgraded cutadapt wrapper
- replicates can be numbers or strings
- more time for fastqc to prevent recurrent timeout errors