### PR TITLE
Fix read stats single-end

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   Linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Lint workflow
       uses: snakemake/snakemake-github-action@v1.25.1
       with:
@@ -22,14 +22,31 @@ jobs:
 
   Testing:
     runs-on: ubuntu-latest
-    needs:
-      - Linting
+    strategy:
+      matrix:
+        paired: [true, false]
+    
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Test workflow
-      uses: snakemake/snakemake-github-action@v1.25.1
-      with:
-        directory: .
-        snakefile: workflow/Snakefile
-        args: "--show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
+      - uses: actions/checkout@v4
+      - name: Test workflow (${{ matrix.paired && 'paired' || 'single-end' }})
+        uses: snakemake/snakemake-github-action@v2.0.3
+        with:
+          task: run
+          stagein: |
+            mkdir -p .test
+            ln -snf ../config .test/config
+            ln -snf ../workflow .test/workflow
+            
+            if [ "${{ matrix.paired }}" = "false" ]; then
+              export ADD_FLAG="--until stats"
+            else
+              export ADD_FLAG=""
+            fi
+          args: >-
+            --directory .test
+            --snakefile workflow/Snakefile
+            --config reads:paired=${{ matrix.paired }}
+            --cores 3
+            --use-conda
+            --show-failed-logs
+            $ADD_FLAG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           args: >-
             --directory .test
             --snakefile workflow/Snakefile
-            --config reads:paired=${{ matrix.paired }}
+            --config ci_paired=${{ matrix.paired }}
             --cores 3
             --use-conda
             --show-failed-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,15 +28,17 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      - name: Test workflow (${{ matrix.paired && 'paired' || 'single-end' }})
+      - name: Test workflow (${{ matrix.paired && 'paired-end' || 'single-end' }})
         uses: snakemake/snakemake-github-action@v2.0.3
         with:
           task: run
           stagein: |
             mkdir -p .test
+            # Create symbolic mirror of project root inside .test
             ln -snf ../config .test/config
             ln -snf ../workflow .test/workflow
             
+            # Handle the conditional flag for single-end mode
             if [ "${{ matrix.paired }}" = "false" ]; then
               export ADD_FLAG="--until stats"
             else

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -60,11 +60,12 @@ tree that will allow you to use gyōza.
 
 It is specific to both the version of gyōza deployed and the DMS project your want to
 analyze, and should make it easier to create a repository for improved reproducibility.
-The ``--tag`` argument accepts any branch or release version tag
+Specify a release version tag for the ``--tag`` argument (latest release to use the
+latest version of gyōza), or a specific commit to use a development version (advanced).
 
 ::
 
-    snakedeploy deploy-workflow https://github.com/durr1602/gyoza my_gyoza_project --tag main
+    snakedeploy deploy-workflow https://github.com/durr1602/gyoza my_gyoza_project --tag v1.2.0
     cd my_gyoza_project
 
 Clone the repository (advanced)

--- a/workflow/envs/main.yaml
+++ b/workflow/envs/main.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - pandas>=2.2.2
-  - numpy>=2.1.0
+  - numpy==2.3.5
   - scipy>=1.15.2
   - matplotlib==3.10.3
   - seaborn>=0.13.2

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -51,15 +51,20 @@ for key in [
         )
     config[key] = cast_to_bool(config[key], key, strict=True)
 
-# Handle nest switch
+# Handle nested switch
 if "reads" not in config or "paired" not in config["reads"]:
     raise KeyError(
         "Config Error: 'reads:paired' is a required entry but was not found."
     )
 
-config["reads"]["paired"] = cast_to_bool(
-    config["reads"].get("paired", True), "reads:paired", strict=True
-)
+if "ci_paired" in config:  # CI hack
+    config["reads"]["paired"] = cast_to_bool(
+        config["ci_paired"], "reads:paired", strict=True
+    )
+else:
+    config["reads"]["paired"] = cast_to_bool(
+        config["reads"].get("paired", True), "reads:paired", strict=True
+    )
 
 validate(config, schema="../schemas/config.schema.yaml")
 print("Main config validated.")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -11,15 +11,14 @@ import warnings
 ##### Helper function to parse user-typed booleans #####
 
 TRUTHY = {"true", "t", "yes", "y", "ok", "1"}
-FALSY = {"false", "f", "no", "n", "0", ""}
+FALSY = {"false", "f", "no", "n", "0"}
 
 
 def cast_to_bool(val, name="value", strict=True):
     """Cast input value to a strict Python boolean based on TRUTHY/FALSY sets."""
     if isinstance(val, bool):
         return val
-
-    s = str(val).strip().lower()
+    s = str(val).strip().lower() if val is not None else ""
     if s in TRUTHY:
         return True
     if s in FALSY:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -8,16 +8,63 @@ from pathlib import Path
 from collections import defaultdict
 import warnings
 
-##### Import and validate main config #####
+##### Helper function to parse user-typed booleans #####
+
+TRUTHY = {"true", "t", "yes", "y", "ok", "1"}
+FALSY = {"false", "f", "no", "n", "0", ""}
+
+
+def cast_to_bool(val, name="value", strict=True):
+    """Cast input value to a strict Python boolean based on TRUTHY/FALSY sets."""
+    if isinstance(val, bool):
+        return val
+
+    s = str(val).strip().lower()
+    if s in TRUTHY:
+        return True
+    if s in FALSY:
+        return False
+
+    if strict:
+        raise ValueError(
+            f"Invalid boolean for {name}: '{val}'. Expected: {TRUTHY| FALSY}"
+        )
+    return False  # default for the sample layout
+
+
+##### Import, parse and validate main config #####
 
 
 configfile: "config/config.yaml"
 
 
+# Parse boolean switches
+for key in [
+    "process_all_samples",
+    "perform_qc",
+    "process_frequencies",
+    "normalize_with_gen",
+]:
+    if key not in config:
+        raise KeyError(
+            f"Config Error: '{key}' is a required boolean switch but was not found."
+        )
+    config[key] = cast_to_bool(config[key], key, strict=True)
+
+# Handle nest switch
+if "reads" not in config or "paired" not in config["reads"]:
+    raise KeyError(
+        "Config Error: 'reads:paired' is a required entry but was not found."
+    )
+
+config["reads"]["paired"] = cast_to_bool(
+    config["reads"].get("paired", True), "reads:paired", strict=True
+)
+
 validate(config, schema="../schemas/config.schema.yaml")
 print("Main config validated.")
 
-##### Paths and other constant variables #####
+##### Paths and other config-based variables #####
 
 PROJECT_DIR = Path(config["project"]["folder"])
 READS_PATH = Path(config["reads"]["path"])
@@ -30,7 +77,7 @@ NBGEN_PATH = PROJECT_DIR / "nbgen.csv"
 SAMPLE_ATTR = config["project"]["sample_attributes"]
 SCREEN_ATTR = config["project"]["screening_attributes"]
 
-##### Import and validate sample layout #####
+##### Import, parse and validate sample layout #####
 
 layout_mandatory_cols = [
     "Sample_name",
@@ -52,11 +99,10 @@ layout_csv = pd.read_csv(LAYOUT_PATH, dtype={"Replicate": str})
 layout_csv["Replicate"] = layout_csv["Replicate"].fillna("").astype(str).str.strip()
 validate(layout_csv, schema="../schemas/sample_layout.schema.yaml")
 
-# Convert Report column to strict boolean
-truthy = {"true", "t", "yes", "y", "ok", "1"}
+# Sanitize Analyze and Report columns
 for col in ["Analyze", "Report"]:
     layout_csv[col] = (
-        layout_csv[col].fillna("").astype(str).str.strip().str.lower().isin(truthy)
+        layout_csv[col].fillna("false").map(lambda x: cast_to_bool(x, strict=False))
     )
 
 # Retrieve non-mandatory columns
@@ -276,7 +322,7 @@ for f in EXPMUT_PATH.glob("*.csv.gz"):
         raise ValueError(
             f"Not all 'nt_seq's have the same length as 'WT_seq' in {f.name}"
         )
-    print(f"Imported expectant mutants of {mutseq}.")
+    print(f"Imported expected mutants of {mutseq}.")
 else:
     expmut_mutseqs = MUTATED_SEQS
 

--- a/workflow/scripts/get_read_stats.py
+++ b/workflow/scripts/get_read_stats.py
@@ -253,6 +253,7 @@ def generate_read_stats(
     else:
         # case when single-end
         fullstats["Total_merged_reads"] = cutadapt_stats["Total_trimmed_reads"]
+        fullstats["Nb_no_merging_solution"] = 0
 
     # Step 3 - Parse vsearch log
     vsearch_stats = parse_vsearch_stats(


### PR DESCRIPTION
- Fixes bug with recent versions of `numpy` that are incompatible with `upsetplot`
- Fixes bug in retrieval of read stats from single-end sequencing data
- Fixes #36 
- Adds CI branch to automatically test single-end analysis (until `rule stats`)
- Truthy/Falsy string values now accepted for boolean switches in the config (same as Analyze/Report columns in the sample layout, except stricter for the config)